### PR TITLE
replaced security with openssl (cert download included)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 coverage
 
 *.sh
+.DS_Store

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 'use strict';
 
 var pkg = require('./package.json');
@@ -10,94 +11,94 @@ var _ = require('lodash');
 var chalk = require('chalk');
 
 var cli = meow({
-  help: [
-    'Example',
-    '  ipa-metadata Facebook.ipa',
-    '',
-    '  ipa-metadata Facebook.ipa --verbose',
-    '',
-    '  ipa-metadata Facebook.ipa --verify',
-    '  (verifies entitlements between `.app` bundle and `embedded.mobileprovision`)',
-    '',
-    '  => data displayed in a table'
-  ].join('\n')
+    help: [
+        'Example',
+        '  ipa-metadata Facebook.ipa',
+        '',
+        '  ipa-metadata Facebook.ipa --verbose',
+        '',
+        '  ipa-metadata Facebook.ipa --verify ',
+        '  (verifies entitlements between `.app` bundle and `embedded.mobileprovision`. Works only on Mac OS X!)',
+        '',
+        '  => data displayed in a table'
+    ].join('\n')
 });
 
 function format(value, compare) {
-  if(!_.isPlainObject(value)) {
-    return value;
-  }
-
-  var string = [];
-  _.each(value, function(value, key) {
-    var shouldCompareEquality = cli.flags.verify && compare;
-
-    if(shouldCompareEquality && (key === 'keychain-access-groups')){
-      return string.push(compareKeychainEntitlement(value, key, compare[key]), '\n');
+    if (!_.isPlainObject(value)) {
+        return value;
     }
 
-    if(shouldCompareEquality){
-      var match = value === compare[key];
-      var stringResult = chalk[match ? 'green' : 'red'](key + ': ' + format(value));
-      return string.push(stringResult, '\n');
-    }
+    var string = [];
+    _.each(value, function(value, key) {
+        var shouldCompareEquality = cli.flags.verify && compare;
 
-    string.push(key, ': ', format(value), '\n');
-  });
-  string.pop();
+        if (shouldCompareEquality && (key === 'keychain-access-groups')) {
+            return string.push(compareKeychainEntitlement(value, key, compare[key]), '\n');
+        }
 
-  return string.join('');
+        if (shouldCompareEquality) {
+            var match = value === compare[key];
+            var stringResult = chalk[match ? 'green' : 'red'](key + ': ' + format(value));
+            return string.push(stringResult, '\n');
+        }
+
+        string.push(key, ': ', format(value), '\n');
+    });
+    string.pop();
+
+    return string.join('');
 }
 
 function compareKeychainEntitlement(value, key, compare) {
-  function splitKeychain(value) {
-    return value[0].split('.')[0];
-  }
+    function splitKeychain(value) {
+        return value[0].split('.')[0];
+    }
 
-  var match = splitKeychain(value) === splitKeychain(compare);
-  return chalk[match ? 'green' : 'red'](key + ': ' + format(value));
+    var match = splitKeychain(value) === splitKeychain(compare);
+    return chalk[match ? 'green' : 'red'](key + ': ' + format(value));
 }
 
-function verboseFormatting(data){
-  var types = Object.keys(data);
+function verboseFormatting(data) {
+    var types = Object.keys(data);
 
-  _.each(types, function(type){
+    _.each(types, function(type) {
+        var table = new Table();
+        _.each(data[type], function(value, key) {
+            table.push([key, format(value)]);
+        });
+
+        console.log(table.toString());
+    });
+}
+
+if (!cli.input[0]) {
+    return cli.showHelp();
+}
+
+ipaMetadata(cli.input[0], function(error, data) {
+    if (error) {
+        return console.log(error.message);
+    }
+
+    if (cli.flags.verbose) {
+        return verboseFormatting(data);
+    }
+
+    var types = {
+        metadata: ['CFBundleDisplayName', 'CFBundleIdentifier', 'CFBundleShortVersionString', 'CFBundleVersion'],
+        provisioning: ['Name', 'TeamIdentifier', 'TeamName', 'CreationDate', 'ExpirationDate', 'Entitlements']
+    };
+
     var table = new Table();
-    _.each(data[type], function(value, key){
-      table.push([key, format(value)]) ;
+    _.each(types, function(keys, type) {
+        if (data[type]) {
+            _.each(keys, function(key) {
+                var value = data[type][key];
+                table.push([key, format(value, data.entitlements)]);
+            });
+        }
     });
 
     console.log(table.toString());
-  });
-}
-
-if(!cli.input[0]){
-  return cli.showHelp();
-}
-
-ipaMetadata(cli.input[0], function(error, data){
-  if(error){
-    return console.log(error.message);
-  }
-
-  if(cli.flags.verbose){
-    return verboseFormatting(data);
-  }
-
-  var types = {
-    metadata: ['CFBundleDisplayName', 'CFBundleIdentifier', 'CFBundleShortVersionString', 'CFBundleVersion'],
-    provisioning: ['Name', 'TeamIdentifier', 'TeamName', 'Entitlements']
-  };
-
-  var table = new Table();
-  _.each(types, function(keys, type) {
-    if(data[type]){
-      _.each(keys, function(key) {
-        var value = data[type][key];
-        table.push([key, format(value, data.entitlements)]);
-      });
-    }
-  });
-
-  console.log(table.toString());
 });

--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ module.exports = function (file, callback){
 
     data.metadata = plist.parse(fs.readFileSync(path + 'Info.plist', 'utf8'));
 
-    if(!fs.existsSync(path + 'embedded.mobileprovision') || !which.sync('security')){
+    if(!fs.existsSync(path + 'embedded.mobileprovision') || !which.sync('openssl')){
       return cleanUp();
     }
-    exec('security cms -D -i embedded.mobileprovision > ' + provisionFilename, { cwd: path }, function(error) {
+    exec('openssl smime -in embedded.mobileprovision -inform der -verify > ' + provisionFilename, { cwd: path }, function(error) {
       if(error){
         cleanUp(error);
       }

--- a/index.js
+++ b/index.js
@@ -14,45 +14,47 @@ var output = new tmp.Dir();
 
 var provisionFilename = 'Provisioning.plist';
 
-module.exports = function (file, callback){
-  var data = {};
+module.exports = function(file, callback) {
+    var data = {};
 
-  var unzipper = new decompress(file);
-  unzipper.extract({
-    path: output.path
-  });
-
-  unzipper.on('error', cleanUp);
-  unzipper.on('extract', function() {
-    var path = glob.sync(output.path + '/Payload/*/')[0];
-
-    data.metadata = plist.parse(fs.readFileSync(path + 'Info.plist', 'utf8'));
-
-    if(!fs.existsSync(path + 'embedded.mobileprovision') || !which.sync('openssl')){
-      return cleanUp();
-    }
-    exec('openssl smime -in embedded.mobileprovision -inform der -verify > ' + provisionFilename, { cwd: path }, function(error) {
-      if(error){
-        cleanUp(error);
-      }
-
-      data.provisioning = plist.parse(fs.readFileSync(path + provisionFilename, 'utf8'));
-      delete data.provisioning.DeveloperCertificates;
-
-      if(!which.sync('codesign')){
-        return cleanUp();
-      }
-
-      exec('codesign -d --entitlements :- ' + path, function(error, output) {
-        data.entitlements = plist.parse(output);
-
-        return cleanUp();
-      });
+    var unzipper = new decompress(file);
+    unzipper.extract({
+        path: output.path
     });
-  });
 
-  function cleanUp(error){
-    rimraf.sync(output.path);
-    return callback(error, data);
-  }
+    unzipper.on('error', cleanUp);
+    unzipper.on('extract', function() {
+        var path = glob.sync(output.path + '/Payload/*/')[0];
+
+        data.metadata = plist.parse(fs.readFileSync(path + 'Info.plist', 'utf8'));
+
+        if (!fs.existsSync(path + 'embedded.mobileprovision') || !which.sync('openssl')) {
+            return cleanUp();
+        }
+        exec('openssl smime -in embedded.mobileprovision -inform der -verify > ' + provisionFilename, {
+            cwd: path
+        }, function(error) {
+            if (error) {
+                cleanUp(error);
+            }
+
+            data.provisioning = plist.parse(fs.readFileSync(path + provisionFilename, 'utf8'));
+            delete data.provisioning.DeveloperCertificates;
+
+            if (!which.sync('codesign')) {
+                return cleanUp();
+            }
+
+            exec('codesign -d --entitlements :- ' + path, function(error, output) {
+                data.entitlements = plist.parse(output);
+
+                return cleanUp();
+            });
+        });
+    });
+
+    function cleanUp(error) {
+        rimraf.sync(output.path);
+        return callback(error, data);
+    }
 };

--- a/lib/CertDownloader.coffee
+++ b/lib/CertDownloader.coffee
@@ -1,0 +1,61 @@
+# The MIT License (MIT)
+
+# Copyright (c) Silas Knobel <dev@katun.ch> (http://katun.ch)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+class CertDownloader
+    constructor: (@certName='AppleIncRootCertificate.cer') ->
+        @fs = require 'fs'
+        @http = require 'http'
+
+    cert: (callback) ->
+        @fs.exists __dirname + @certName, (exists) =>
+            if exists is true
+                callback __dirname + '/' + @certName
+            else
+                #download the cert
+                downloadStream = @fs.createWriteStream __dirname + '/' + @certName
+
+                @http.get 'http://www.apple.com/appleca/AppleIncRootCertificate.cer', (response) =>
+                    response.pipe downloadStream
+                    downloadStream.on 'finish', () =>
+                        downloadStream.close () =>
+                            callback __dirname + '/' + @certName
+
+    pem: (callback) ->
+        splits = @certName.split '.'
+        pemFileName = splits[0] + '.pem'
+        @fs.exists __dirname + '/' + pemFileName, (exists) =>
+            if exists is true
+                callback __dirname + '/' + pemFileName
+            else
+                @cert (certPath) =>
+                    {exec} = require 'child_process'
+                    execOptions =
+                        cwd: __dirname
+
+                    exec 'openssl x509 -inform der -in '+@certName+' -out ' + pemFileName, execOptions, (error) ->
+                        if error is not undefined
+                            callback undefined, error
+                        else
+                            callback __dirname + '/' + pemFileName
+
+module.exports = CertDownloader

--- a/lib/CertDownloader.js
+++ b/lib/CertDownloader.js
@@ -1,0 +1,90 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) Silas Knobel <dev@katun.ch> (http://katun.ch)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+'use strict';
+
+
+var CertDownloader;
+
+CertDownloader = (function() {
+  function CertDownloader(certName) {
+    this.certName = certName != null ? certName : 'AppleIncRootCertificate.cer';
+    this.fs = require('fs');
+    this.http = require('http');
+  }
+
+  CertDownloader.prototype.cert = function(callback) {
+    return this.fs.exists(__dirname + this.certName, (function(_this) {
+      return function(exists) {
+        var downloadStream;
+        if (exists === true) {
+          return callback(__dirname + '/' + _this.certName);
+        } else {
+          downloadStream = _this.fs.createWriteStream(__dirname + '/' + _this.certName);
+          return _this.http.get('http://www.apple.com/appleca/AppleIncRootCertificate.cer', function(response) {
+            response.pipe(downloadStream);
+            return downloadStream.on('finish', function() {
+              return downloadStream.close(function() {
+                return callback(__dirname + '/' + _this.certName);
+              });
+            });
+          });
+        }
+      };
+    })(this));
+  };
+
+  CertDownloader.prototype.pem = function(callback) {
+    var pemFileName, splits;
+    splits = this.certName.split('.');
+    pemFileName = splits[0] + '.pem';
+    return this.fs.exists(__dirname + '/' + pemFileName, (function(_this) {
+      return function(exists) {
+        if (exists === true) {
+          return callback(__dirname + '/' + pemFileName);
+        } else {
+          return _this.cert(function(certPath) {
+            var exec, execOptions;
+            exec = require('child_process').exec;
+            execOptions = {
+              cwd: __dirname
+            };
+            return exec('openssl x509 -inform der -in ' + _this.certName + ' -out ' + pemFileName, execOptions, function(error) {
+              if (error === !void 0) {
+                return callback(void 0, error);
+              } else {
+                return callback(__dirname + '/' + pemFileName);
+              }
+            });
+          });
+        }
+      };
+    })(this));
+  };
+
+  return CertDownloader;
+
+})();
+
+module.exports = CertDownloader;

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,10 @@ The CLI is very useful for quickly checking the entitlements of an `.ipa` file (
   
 See ["Checking the Entitlements of an .ipa file"](https://developer.apple.com/library/ios/qa/qa1798/_index.html#//apple_ref/doc/uid/DTS40014167-CH1-INSPECT_IPA) for more information
 
+__Note__
+
+The `--verify` flag works only on Mac OS X with Xcode installed. On other systems (or without Xcode installed) it will not checking the entitlements with the provisioning profile. 
+
 ## Install
 
 ```sh
@@ -53,7 +57,7 @@ $ ipa-metadata --help
     ipa-metadata Facebook.ipa --verbose
     
     ipa-metadata Facebook.ipa --verify
-    (verifies entitlements between `.app` bundle and `embedded.mobileprovision`)
+    (verifies entitlements between `.app` bundle and `embedded.mobileprovision`. Works only on Mac OS X!)
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ I created a [quick Bash script](https://gist.github.com/matiassingers/4766348918
 
 The CLI is very useful for quickly checking the entitlements of an `.ipa` file (`--verify`), and two types will be returned from the module:
   - `.app` bundle with [`codesign`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/codesign.1.html)
-  - `embedded.mobileprovision` with [`security`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/security.1.html)
+  - `embedded.mobileprovision` with [`openssl`](https://www.openssl.org/docs/apps/openssl.html)
   
 See ["Checking the Entitlements of an .ipa file"](https://developer.apple.com/library/ios/qa/qa1798/_index.html#//apple_ref/doc/uid/DTS40014167-CH1-INSPECT_IPA) for more information
 


### PR DESCRIPTION
hi again

now the module will download the certificate from apple to read the mobile provision profile.
I've tested it on Ubuntu 14.04.1 LTS and it's able to read the `embedded.mobileprovision` using openssl.

`codesign` respectively the `--verify` flag will not work on other systems than Mac OS X.

pls test it on your machine and update the node module. 

cheerio
silas