### PR TITLE
[bugfix] escape whitespace for filepath. Use nodejs path to make path

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var entitlements = require('entitlements');
 var rimraf = require('rimraf');
 var tmp = require('temporary');
 var glob = require("glob");
+var Path = require('path');
 
 var output = new tmp.Dir();
 
@@ -24,10 +25,11 @@ module.exports = function (file, callback){
   unzipper.on('extract', function() {
     var path = glob.sync(output.path + '/Payload/*/')[0];
 
-    data.metadata = plist.readFileSync(path + 'Info.plist');
+    data.metadata = plist.readFileSync(Path.join(path, 'Info.plist'));
+    path = path.replace(/ /g, '\\ ');
 
     var tasks = [
-      async.apply(provisioning, path + 'embedded.mobileprovision')
+      async.apply(provisioning, Path.join(path, 'embedded.mobileprovision'))
     ];
 
     // `entitlements` relies on a OS X only CLI tool called `codesign`


### PR DESCRIPTION
There's a problem for parsing ipa file of which scheme has whitespace in it.
When the scheme name has whitespace, generated `.ipa` file has white-spaced `.app` file in it.
Because of this, several failure can occur on this library. So I escaped path before use, but when I try to escape spaces right before `plist.readFileSync`, it throws me an error. (I think it is because it escapes filename internally). 

Other than reading plist, `path` are used for concatenating command forked by `exec`, so I think it will be fine in most cases. Consider this PR, and please fix this bug. Thanks.
