### PR TITLE
Fix error when parse .ipa files simultaneously

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,9 @@ var rimraf = require('rimraf');
 var tmp = require('temporary');
 var glob = require("glob");
 
-var output = new tmp.Dir();
-
 module.exports = function (file, callback){
   var data = {};
+  var output = new tmp.Dir();
 
   var unzipper = new decompress(file);
   unzipper.extract({


### PR DESCRIPTION
Thank you for providing verify useful npm module!

I'm using this module in a NodeJS server, then I notice the function fails when parse some `.ipa` files simultaneously. It's is due to the temp directory is always same.